### PR TITLE
Feature/893 select all checkbox wording

### DIFF
--- a/src/components/CheckboxGroup/CheckboxGroup.js
+++ b/src/components/CheckboxGroup/CheckboxGroup.js
@@ -37,7 +37,7 @@ const CheckboxGroup = (props) => {
           <div className="flex-align-self-center clearfix font-sans-sm text-italic">
             <Checkbox
               id={`${props.name}${showActiveInId}`}
-              label="Select All"
+              label={`All ${props.name}`}
               name={props.name}
               checked={evaluateSelectAll()}
               onChange={props.onSelectAll}

--- a/src/components/CheckboxGroup/CheckboxGroup.js
+++ b/src/components/CheckboxGroup/CheckboxGroup.js
@@ -41,6 +41,7 @@ const CheckboxGroup = (props) => {
               name={props.name}
               checked={evaluateSelectAll()}
               onChange={props.onSelectAll}
+              data-testid="select-all"
             />
           </div>
         ) : null}

--- a/src/components/ProgramRenderer/ProgramRenderer.test.js
+++ b/src/components/ProgramRenderer/ProgramRenderer.test.js
@@ -213,7 +213,7 @@ const storeProgam = restructurePrograms(program);
 
 describe('Program renderer Component', () => {
   it('renders form elements without errors for active retired and enable select all flags set to true', () => {
-    const { getAllByLabelText, getAllByTestId, getAllByRole, getByText } = render(
+    const { getAllByTestId, getAllByRole, getByText } = render(
       <ProgramRenderer
         showActiveRetired={true}
         showActive={true}
@@ -233,7 +233,7 @@ describe('Program renderer Component', () => {
     const groupNames = getAllByTestId('program-group-name')
     expect(groupNames).toHaveLength(4)
 
-    const selectAllCheckBoxes = getAllByLabelText('Select All')
+    const selectAllCheckBoxes = getAllByTestId('select-all')
     expect(selectAllCheckBoxes).toHaveLength(4)
 
     const checkbox = getAllByRole('checkbox')
@@ -242,7 +242,7 @@ describe('Program renderer Component', () => {
   });
 
   it('renders form elements without errors for active retired and enable select all falgs set to false', () => {
-    const { getAllByTestId, getAllByRole, queryByText, queryAllByLabelText } = render(
+    const { getAllByTestId, getAllByRole, queryByText } = render(
       <ProgramRenderer
         showActiveRetired={false}
         showActive={false}
@@ -259,8 +259,6 @@ describe('Program renderer Component', () => {
 
     const groupNames = getAllByTestId('program-group-name')
     expect(groupNames).toHaveLength(2)
-
-    expect(queryAllByLabelText('Select All')).toHaveLength(0);
 
     const checkbox = getAllByRole('checkbox')
     expect(checkbox).toHaveLength(storeProgam[0].items.length + storeProgam[1].items.length)

--- a/src/components/UnitTypeRenderer/UnitTypeRenderer.test.js
+++ b/src/components/UnitTypeRenderer/UnitTypeRenderer.test.js
@@ -163,7 +163,7 @@ const storeUnitType = restructureUnitTypes(unitType);
 
 describe('Unit Type Renderer Component', () => {
   it('renders form elements without errors for Boilers and Turbines groups', () => {
-    const { getAllByLabelText, getAllByRole, getByText } = render(
+    const { getAllByTestId, getAllByRole, getByText } = render(
       <UnitTypeRenderer
         showActiveRetired={false}
         items={storeUnitType}
@@ -178,7 +178,7 @@ describe('Unit Type Renderer Component', () => {
     const turbinesHeader = getByText('Turbines');
     expect(turbinesHeader).toBeInTheDocument();
 
-    const selectAllCheckBoxes = getAllByLabelText('Select All');
+    const selectAllCheckBoxes = getAllByTestId('select-all');
     expect(selectAllCheckBoxes).toHaveLength(2);
 
     const checkbox = getAllByRole('checkbox');

--- a/src/components/hourlyEmissions/UnitType/UnitType.test.js
+++ b/src/components/hourlyEmissions/UnitType/UnitType.test.js
@@ -187,11 +187,11 @@ describe('Hourly Emissions Unit Type', () => {
   afterEach(cleanup);
 
   it('Check that the component properly renders', () => {
-    const { getByText, getAllByLabelText, getAllByRole } = queries;
+    const { getByText, getAllByTestId, getAllByRole } = queries;
     expect(getByText('Boilers')).toBeInTheDocument();
     expect(getByText('Turbines')).toBeInTheDocument();
 
-    const selectAllCheckBoxes = getAllByLabelText('Select All');
+    const selectAllCheckBoxes = getAllByTestId('select-all');
     expect(selectAllCheckBoxes).toHaveLength(2);
 
     const checkbox = getAllByRole('checkbox');


### PR DESCRIPTION
## Pull Request

- adjusted wording on select all checkbox to now say "All Boilers" / "All Turbines"
