### PR TITLE
Bug/1607-fix-quarter-label

### DIFF
--- a/src/components/dataPreview/QuarterlyEmissions/QuarterlyEmissions.js
+++ b/src/components/dataPreview/QuarterlyEmissions/QuarterlyEmissions.js
@@ -54,7 +54,7 @@ export const QuarterlyEmissions = ({
         accessor: 'col6',
       },
       {
-        Header: 'Month',
+        Header: 'Quarter',
         accessor: 'col7',
       },
       {


### PR DESCRIPTION
## Pull Request

- Fixed typo that was labeled "Month" to "Quarter"
