### PR TITLE
Bug/2501 Endpoints not querying up until 2022

### DIFF
--- a/src/components/filterCriteria/timePeriod/TimePeriodFullDate/TimePeriodFullDate.js
+++ b/src/components/filterCriteria/timePeriod/TimePeriodFullDate/TimePeriodFullDate.js
@@ -29,7 +29,7 @@ const TimePeriodFullDate = ({
 
   const rangeMessage = isAllowance
     ? 'Enter dates between 03/23/1993 and the current date'
-    : `Enter dates between 01/01/1995 and the end of the calendar quarter, ${reportingQuarter()}`;
+    : `Enter dates between 01/01/1995 and the quarter ending on ${reportingQuarter()}`;
 
   return (
     <>

--- a/src/components/filterCriteria/timePeriod/TimePeriodYear/TimePeriodYear.js
+++ b/src/components/filterCriteria/timePeriod/TimePeriodYear/TimePeriodYear.js
@@ -27,16 +27,16 @@ const TimePeriodYear = ({
 }) => {
   let rangeMessage;
   if (showMonth) {
-    rangeMessage = `Enter month(s) and year(s) between 01/01/1995 and the end of the calendar quarter, ${reportingQuarter()}`;
+    rangeMessage = `Enter month(s) and year(s) between 01/01/1995 and the quarter ending on ${reportingQuarter()}`;
   } else if (showQuarter) {
-    rangeMessage = `Enter quarter(s) and year(s) between 01/01/1995 and the end of the calendar quarter, ${reportingQuarter()}`;
+    rangeMessage = `Enter quarter(s) and year(s) between 01/01/1995 and the quarter ending on ${reportingQuarter()}`;
   } else if (isAnnual) {
     rangeMessage =
-      'Enter year(s) 1980, 1985, 1990, or a year between 1995 and this year';
+      `Enter year(s) 1980, 1985, 1990, or a year between 1995 and the quarter ending on ${reportingQuarter()}`;
   } else if (isAllowance) {
     rangeMessage = 'Enter year(s) greater than or equal to 1995';
   } else {
-    rangeMessage = `Enter year(s) between ${minYear} and this year`;
+    rangeMessage = `Enter year(s) between ${minYear} and and the quarter ending on ${reportingQuarter()}`;
   }
 
   let yearLabel = 'Year(s)'

--- a/src/utils/dateValidation/dateValidation.js
+++ b/src/utils/dateValidation/dateValidation.js
@@ -64,6 +64,7 @@ export const isYearFormat = (yearString) => {
 };
 
 export const isInYearRange = (yearArray, minYear, isAnnual = false, isAllowance = false) => {
+  const curDate = new Date();
   const curYear = new Date().getFullYear();
   let result = false;
    if (isAnnual) {
@@ -72,12 +73,21 @@ export const isInYearRange = (yearArray, minYear, isAnnual = false, isAllowance 
          year === 1980 ||
          year === 1985 ||
          year === 1990 ||
-         (year >= 1995 && year <= curYear)
+         (year >= 1995 &&
+           year <= curYear &&
+           curDate >= new Date(`March 31, ${curYear}`)) ||
+         (year >= 1995 && year <= curYear - 1)
      );
    } else if (isAllowance) {
      result = yearArray.every((year) => year >= 1995);
    } else {
-     result = yearArray.every((year) => year >= minYear && year <= curYear);
+     result = yearArray.every(
+       (year) =>
+         (year >= minYear &&
+           year <= curYear &&
+           curDate >= new Date(`March 31, ${curYear}`)) ||
+         (year >= minYear && year <= curYear - 1)
+     );
    }
 
     if (!result) {

--- a/src/utils/selectors/general.js
+++ b/src/utils/selectors/general.js
@@ -103,7 +103,7 @@ export const reportingQuarter = () => {
   const curYear = new Date().getFullYear();
   let quarter;
   if (curDate < new Date(`March 31, ${curYear}`)) {
-    quarter = `12/31/'${curYear - 1}`;
+    quarter = `12/31/${curYear - 1}`;
   } else if (curDate < new Date(`June 30, ${curYear}`)) {
     quarter = `03/31/${curYear}`;
   } else if (curDate < new Date(`September 30, ${curYear}`)) {


### PR DESCRIPTION
## Pull Request

```
- Modify time period error messages for hourly, daily, monthly, quarterly, annual, ozone emissions
- Modify time period error messages for facility/unit attributes
- Modify time period validation for annual, ozone, and facility/unit attributes to account for reporting quarter so it doesn't accept the current year until the 1st quarter is complete 

```
