### PR TITLE
release/v1.0 memory config changes

### DIFF
--- a/manifest-vars.yml
+++ b/manifest-vars.yml
@@ -1,7 +1,6 @@
 #THIS FILE SHOULD CONTAIN DEV SETTINGS AND CI/CD WORKFLOW WILL CHANGE SETTINGS BASED ON ENV
 name: campd-ui
 memory: 2048
-heap: 1536
 disk: 2048
 instances: 1
 environment: development

--- a/manifest.yml
+++ b/manifest.yml
@@ -18,6 +18,5 @@ applications:
       REACT_APP_GOOGLE_ANALYTICS_CONTAINER_ID: ((googleAnalyticsContainerId))
       REACT_APP_GOOGLE_ANALYTICS_ENABLED: ((googleAnalyticsEnabled))
       REACT_APP_EASEY_CAMPD_UI_STREAMING_LIMIT: ((streamingLimit))
-      NODE_OPTIONS: --max-old-space-size=((heap))
     routes:
       - route: ((host))


### PR DESCRIPTION
merging memory config changes and removing NODE_OPTIONS env var since build pack sets to 75% available memory