### PR TITLE
fix:added condition for fetching filterCritera program

### DIFF
--- a/src/store/actions/customDataDownload/filterCriteria.js
+++ b/src/store/actions/customDataDownload/filterCriteria.js
@@ -297,7 +297,7 @@ export const loadAllFilters = (dataType, dataSubType, filterCriteria, bookmarkFi
   const promises=[];
   const apiCallOrder=[];
   return(dispatch) => {
-    if(filters.includes(API_CALLING_FILTERS[0])){
+    if(filterCriteria.program.length === 0 && filters.includes(API_CALLING_FILTERS[0])){
       dispatch(beginApiCall());
       promises.push(filterCriteriaApi.getPrograms(dataType, dataSubType === "Holdings"? true : false));
       apiCallOrder.push(API_CALLING_FILTERS[0]);


### PR DESCRIPTION
## Ticket
[Filters not maintained when switching emissions aggregation BUG](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/4903)

## Changes

- Added condition for fetching filterCritera program

## Step to test

1. Navigate to http://localhost:3000/data/custom-data-download
2. Select Data Type as `Emissions` & Data Subtype as `Daily Emissions` and `Apply`
3. Enter Time Period (eg: Start Date `01/01/2019` & End Date `01/01/2019`) and `Apply Filter`
4. Select Program (eg: Acid Rain Program (ARP)) and `Apply Filter`
5. Press `Change` button (left top) 
6. Select Aggregation as `Facility` and `Apply`
7. Check selected Program are still checked.