### PR TITLE
fix:account number convert to lowercase

### DIFF
--- a/src/components/MultiSelectCombobox/MultiSelectCombobox.js
+++ b/src/components/MultiSelectCombobox/MultiSelectCombobox.js
@@ -175,13 +175,14 @@ const MultiSelectCombobox = ({
       invalidEntries = [];
     itemsCopy.forEach((item) => {
       let { label, id } = item;
+      const _id = id.toLowerCase();
       label = label.toString();
       const name = label.split("(")[0].slice(0, -1).toLowerCase();
-      if (searchValueObj[id] || searchValueObj[name]) {
+      if (searchValueObj[_id] || searchValueObj[name]) {
         item.selected = true;
         filteredItems.push(item);
-        if (searchValueObj[id]) {
-          searchValueObj[id] = "valid";
+        if (searchValueObj[_id]) {
+          searchValueObj[_id] = "valid";
         }
         if (searchValueObj[label.toLowerCase()]) {
           searchValueObj[label.toLowerCase()] = "valid";


### PR DESCRIPTION
## Ticket
[Account Name/Number Copy/Paste BUG](https://app.zenhub.com/workspaces/dpcerg-scrum-board-5f36cc8dfed6db0022b0f4db/issues/gh/us-epa-camd/easey-ui/4550)

## Changes

- For finding `accountName`, input values were already converted `toLowerCase`, so I convert `accountNumber` `toLowerCase` and find.

## Step to test

1. Navigate to http://localhost:3000/data/custom-data-download
2. Select Data Type as `Allowance` & Data Subtype as `Account Information` and `Apply`
3. In filter select `Account Name/Number` and copy paste `000003FACLTY | 000005FACLTY ` and press `Enter`
4. Check the values are accepting 