### PR TITLE
Max-age change to min default

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -37,8 +37,8 @@ http {
     # Do not let attackers downgrade the ciphersuites. Always use server-side offered ciphersuites
     ssl_prefer_server_ciphers on;
 
-    # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
-    add_header Strict-Transport-Security max-age=15768000;
+    # HSTS (ngx_http_headers_module is required) (31536000 seconds = 12 months)
+    add_header Strict-Transport-Security max-age=31536000;
 
     location /dev {
       return 404;


### PR DESCRIPTION
Max-age needs to be set to min the default of 1 yr. as opposed to 6 months as currently set. 