### PR TITLE
enable content security policy

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -40,6 +40,14 @@ http {
     # HSTS (ngx_http_headers_module is required) (31536000 seconds = 12 months)
     add_header Strict-Transport-Security max-age=31536000;
 
+    # CSP (Content-Security-Policy)
+    # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';";
+    # X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)
+    add_header X-Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';"; 
+    # X-WebKit-CSP (for Chrome 14+ and Safari 6+)
+    add_header X-WebKit-CSP "default-src 'self'; script-src 'self'; style-src 'self';"; 
+
     location /dev {
       return 404;
     }


### PR DESCRIPTION
## Ticket 
[Enable CSP (Content-Security-Policy)](https://github.com/US-EPA-CAMD/easey-ui/issues/6101)

## Changes

- Enable Content Security Policy

   #### 1. Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
   ` add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';";`
    #### 2.  X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)
    `add_header X-Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';";`
    #### 3. X-WebKit-CSP (for Chrome 14+ and Safari 6+)
    `add_header X-WebKit-CSP "default-src 'self'; script-src 'self'; style-src 'self';";`

 
