### PR TITLE
enable content security policy with allowing api.epa.gov

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -42,11 +42,11 @@ http {
 
     # CSP (Content-Security-Policy)
     # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';";
+    add_header Content-Security-Policy "default-src 'self' api.epa.gov;";
     # X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)
-    add_header X-Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self';"; 
+    add_header X-Content-Security-Policy "default-src 'self' api.epa.gov;"; 
     # X-WebKit-CSP (for Chrome 14+ and Safari 6+)
-    add_header X-WebKit-CSP "default-src 'self'; script-src 'self'; style-src 'self';"; 
+    add_header X-WebKit-CSP "default-src 'self' api.epa.gov;";
 
     location /dev {
       return 404;


### PR DESCRIPTION
## Ticket 
[Enable CSP (Content-Security-Policy)](https://github.com/US-EPA-CAMD/easey-ui/issues/6101)

## Changes

- Enable Content Security Policy with allowing api.epa.gov

   #### 1. Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
   ` add_header Content-Security-Policy "default-src 'self' api.epa.gov;";`
    #### 2.  X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)
    `add_header X-Content-Security-Policy ""default-src 'self' api.epa.gov;";`
    #### 3. X-WebKit-CSP (for Chrome 14+ and Safari 6+)
    `add_header X-WebKit-CSP "default-src 'self' api.epa.gov;";`
