### PR TITLE
enable content security policy 

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -42,11 +42,11 @@ http {
 
     # CSP (Content-Security-Policy)
     # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
-    add_header Content-Security-Policy "default-src 'self' api.epa.gov; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; img-src 'self' data:image;";
+    add_header Content-Security-Policy "default-src 'self' api.epa.gov; script-src 'self'; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data:; font-src 'self' https:;";
     # X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)
-    add_header X-Content-Security-Policy "default-src 'self' api.epa.gov; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; img-src 'self' data:image;"; 
+    add_header X-Content-Security-Policy "default-src 'self' api.epa.gov; script-src 'self'; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data:; font-src 'self' https:;"; 
     # X-WebKit-CSP (for Chrome 14+ and Safari 6+)
-    add_header X-WebKit-CSP "default-src 'self' api.epa.gov; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; img-src 'self' data:image;";
+    add_header X-WebKit-CSP "default-src 'self' api.epa.gov; script-src 'self'; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data:; font-src 'self' https:;";
 
     location /dev {
       return 404;

--- a/nginx.conf
+++ b/nginx.conf
@@ -42,11 +42,11 @@ http {
 
     # CSP (Content-Security-Policy)
     # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
-    add_header Content-Security-Policy "default-src 'self' api.epa.gov;";
+    add_header Content-Security-Policy "default-src 'self' api.epa.gov; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; img-src 'self' data:image;";
     # X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)
-    add_header X-Content-Security-Policy "default-src 'self' api.epa.gov;"; 
+    add_header X-Content-Security-Policy "default-src 'self' api.epa.gov; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; img-src 'self' data:image;"; 
     # X-WebKit-CSP (for Chrome 14+ and Safari 6+)
-    add_header X-WebKit-CSP "default-src 'self' api.epa.gov;";
+    add_header X-WebKit-CSP "default-src 'self' api.epa.gov; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='; img-src 'self' data:image;";
 
     location /dev {
       return 404;

--- a/public/index.html
+++ b/public/index.html
@@ -19,16 +19,6 @@
     <meta name="MobileOptimized" content="width" />
     <meta name="HandheldFriendly" content="true" />
 
-    <!-- <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self' api.epa.gov; script-src 'self'; style-src 'unsafe-inline'; style-src-elem 'self' 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-RSPDgXY6hCckrD/H++wJX3mk1qT2wd5wqAlidDts2OM=' 'sha256-1LwPa7D6B+SaCtdC7VVRy7DAmS5BHvGYNOFrzBLyb+c=' 'sha256-h+oVhgAMaDxpgCofntDDKHN/ub5fbqD75p6uIhgvsvM=' 'sha256-nmoC4BrTr0v/v4I19YsSwZP7MzNSWqYgilHn0quK2qU=' 'sha256-dGpcYs81zJuoiL0rVy0ftdzumug5mBaROc67Q+TYa78=' 'sha256-VlRmJDUdQs8CVJpjocMeREvqpKtpUwVxVafRhRYFiSA=' 'sha256-2Bl/i2GIs6uZ3cM0gBx1xTZIEsnNIHbW69epTv3Ghzc=' 'sha256-jKHm3/RRBPwhy/u77WBBjgF64YEZEAhF5wifc4jt+aw=' 'sha256-mRId7lkKOvgJYT4qts1WaiaF+2+N/okKCfvkj3lfngY=' 'sha256-NpTjsHMF6uXs4LiRwnR43Dnh2HHUAxqWcWGBL/bIyUw=' 'sha256-DMWNAEYV3gkdWOyYY27ML9KV1Oa2CxcNuPNHwXjYs7c=' 'sha256-AmF7Tn75M/EAi71/CpwbSmWZjYtinCPbdOucbSMWmAA=' 'sha256-/mnEy93oxsstnD9r6zHai094EK2qdW89Wqm6pf4+bmg=' 'sha256-soVFpjO9fBe2HCvSa1KYQRUlvHaq7RVBTeI8gyYOgMw=' 'sha256-6oYe0gg1OVOw1OFOmNsC3BrqfU0OC3+DTyJHMmu2+jY=' 'sha256-h3KH72vPR1zwGAzsKCTJ9GXkfkir8KeN2+qirC0tOLg=' 'sha256-05jae+fuyFrUa0X30IFDem7EltgHdG/9lrNrl9VJss4=' 'sha256-b8mZuPNn15QvJ4ZUb7W8t2rsnIs2/ZtN3pThwqvlxn8=' 'sha256-tIwHhAPIyXlSZMT7KzamwCmY/hs2BT6B46tjI1EJ+uE=' 'sha256-/W3C62XsWR741eAI6X8uy+iN8dO9i6ORYPYT5lLR/eI=' 'sha256-XSjMsU56YZYLGudNW21E5FWF5vWE6Atd5f7mNOTUQyc=' 'sha256-7hf7zEIeHMqgGFNoDAJOU4QqW1YfOah69pPscTos7mw=' 'sha256-c2NGfDEFL/QU0SCsgD2FCWxS9SO2H5/8MnKVtK/NF9U=' 'sha256-60y3ZfJIwjt403Hwvv/TwyRRjiso5h/y4v17m9BmlsM=' 'sha256-X/8KD9CMJZ4EH24yF/uV+f9vkJ2rxXJZqw+kulb+uvA=' 'sha256-WWL0xnR8N0yQW5PGWdVbgy/A7/U1QUHFlPZDvoik060=' 'sha256-Pk4ncOX776mG0uCG139/MexpIPWhk4dVQ12SzeoNC2g=' 'sha256-PtixzyDv9tfdYlV1D2WJlNvAcxRMui0nNDRNKfoyEKo=' 'sha256-3Z6N6lvE4kbYMZ6dxnARA87gwcvjljT11W1+aUyVwfw=' 'sha256-6ou17Lvkn9cNgUt9UC6fUARLJjdz3COjMdiMNFugD7c=' 'sha256-8fcJuMWQOmKh/Dvp7c1x7RX8kFW4+WlEErxouDi3gME=' 'sha256-naz0HJwEM1RpppeWVamf/AhQvtjXkTCnd4Neh6Pdp0Y=' 'sha256-iXoTNuMti+pLJMPcF7erhEYYu9QbZbzI9FmBAdewogQ=' 'sha256-tekUYy0NkA+O1VOKFNT8dKWreGklo3ejoHu6gC++VBI=' 'sha256-AbpHGcgLb+kRsJGnwFEktk7uzpZOCcBY74+YBdrKVGs=' 'sha256-m9C3ibQ7/MuOKw17/yE5bYRuDJAxyp9QzejqJPbEqos=' https://fonts.googleapis.com; img-src 'self' api.epa.gov data:; font-src 'self' https://fonts.gstatic.com;"
-    /> -->
-
-    <!-- <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self' api.epa.gov; script-src 'self'; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data:; font-src 'self' https:;"
-    /> -->
-
     <script src="/env-config.js"></script>
 
     <link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
## Ticket
[Enable CSP (Content-Security-Policy)](https://github.com/US-EPA-CAMD/easey-ui/issues/6101)

## Changes 

- Enable Content Security Policy
    `default-src 'self' api.epa.gov; script-src 'self'; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data:; font-src 'self' https:;`