### PR TITLE
Ticket 6361, 508 error on Vintage Year field

### DIFF
--- a/src/components/filterCriteria/timePeriod/TimePeriodComboBox/TimePeriodComboBox.js
+++ b/src/components/filterCriteria/timePeriod/TimePeriodComboBox/TimePeriodComboBox.js
@@ -104,7 +104,7 @@ const TimePeriodComboBox = ({
             <MultiSelectCombobox
               items={JSON.parse(JSON.stringify(timePeriod.comboBoxYear))}
               label={`Select or Search ${filterToApply}s`}
-              entity={`${filterToApply.toLowerCase()}s`}
+              entity={`${filterToApply.toLowerCase().replace(/\s+/g, '-')}s`}
               onChangeUpdate={onChangeUpdate}
               searchBy="beginsWith"
             />


### PR DESCRIPTION
## Pull Request

Ticket 6361, fixed the following error on the element "Vintage Year": Improper use of [aria-labelledby] possible: Referenced ids "vintage,years-label" not found.