### PR TITLE
resolve JSON hijacking vulnerability

### DIFF
--- a/src/components/MultiSelectCombobox/MultiSelectCombobox.js
+++ b/src/components/MultiSelectCombobox/MultiSelectCombobox.js
@@ -175,7 +175,7 @@ const MultiSelectCombobox = ({
       invalidEntries = [];
     itemsCopy.forEach((item) => {
       let { label, id } = item;
-      const _id = id.toLowerCase();
+      const _id = id?.toString().toLowerCase() || '';
       label = label.toString();
       const name = label.split("(")[0].slice(0, -1).toLowerCase();
       if (searchValueObj[_id] || searchValueObj[name]) {

--- a/src/store/actions/bulkDataFilesActions.js
+++ b/src/store/actions/bulkDataFilesActions.js
@@ -16,7 +16,7 @@ export function loadBulkDataFiles() {
     return camdApi
       .getBulkDataFilesList(()=>dispatch(setApiError('bulkDataFiles', true)))
       .then((res) => {
-        if(res){dispatch(loadBulkDataFilesSuccess(res.data.items))};
+        if(res){dispatch(loadBulkDataFilesSuccess(res.data.items ?? res.data))}
       })
       .catch((err) => {
         dispatch(setApiError('bulkDataFiles', true))

--- a/src/store/actions/bulkDataFilesActions.js
+++ b/src/store/actions/bulkDataFilesActions.js
@@ -16,7 +16,7 @@ export function loadBulkDataFiles() {
     return camdApi
       .getBulkDataFilesList(()=>dispatch(setApiError('bulkDataFiles', true)))
       .then((res) => {
-        if(res){dispatch(loadBulkDataFilesSuccess(res.data))};
+        if(res){dispatch(loadBulkDataFilesSuccess(res.data.items))};
       })
       .catch((err) => {
         dispatch(setApiError('bulkDataFiles', true))

--- a/src/store/actions/bulkDataFilesActions.test.js
+++ b/src/store/actions/bulkDataFilesActions.test.js
@@ -16,7 +16,7 @@ describe("bulk data files Async Actions", () => {
   });
   it("should create BEGIN_API_CALL and LOAD_BULK_DATA_FILES_SUCCESS when loading list of bulk data files", () => {
     
-    const mockGetBulkDataFilesList = jest.fn().mockResolvedValue({data: [...mockBulkDataFilesRecords]});
+    const mockGetBulkDataFilesList = jest.fn().mockResolvedValue({ data: { items: [...mockBulkDataFilesRecords]} });
     jest.spyOn(camdApi, "getBulkDataFilesList").mockImplementation(mockGetBulkDataFilesList); 
 
     const expectedActions = [

--- a/src/store/actions/customDataDownload/filterCriteria.js
+++ b/src/store/actions/customDataDownload/filterCriteria.js
@@ -356,7 +356,7 @@ export const loadAllFilters = (dataType, dataSubType, filterCriteria, bookmarkFi
       .then((values) => {
         values.forEach((value, index) =>{
          if(value){
-          dispatchAction(value.data, apiCallOrder[index], dispatch, bookmarkFilters)
+          dispatchAction(value.data?.items ?? value.data, apiCallOrder[index], dispatch, bookmarkFilters)
          }
         });
       })


### PR DESCRIPTION
camd-services changed to resolve JSON hijacking vulnerability by returning an ArrayResponse object instead of returning an array directly from an API. ECMPS UI updated to handle that.