### PR TITLE
fix(6555): changed NGINX replacement string to avoid collision

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -50,7 +50,7 @@ http {
     add_header X-WebKit-CSP $csp;
 
     sub_filter_once off;
-    sub_filter "{{nonce}}" $request_id;
+    sub_filter "###NONCE###" $request_id;
 
     location /dev {
       return 404;

--- a/public/error404.html
+++ b/public/error404.html
@@ -14,11 +14,11 @@
 
   <script src="/env-config.js"></script>
   
-    <script nonce="{{nonce}}">
-    window.__CSP_NONCE__ = "{{nonce}}";
+    <script nonce="###NONCE###">
+    window.__CSP_NONCE__ = "###NONCE###";
   </script>
 
-    <script language="javascript" nonce="{{nonce}}">
+    <script language="javascript" nonce="###NONCE###">
     function toggleGovBanner(obj) {
       var ariaExpanded = obj.getAttribute("aria-expanded");
       obj.setAttribute("aria-expanded", ariaExpanded === "true" ? "false" : "true");

--- a/public/index.html
+++ b/public/index.html
@@ -21,8 +21,8 @@
 
     <script src="/env-config.js"></script>
 
-    <script nonce="{{nonce}}">
-      window.__CSP_NONCE__ = "{{nonce}}";
+    <script nonce="###NONCE###">
+      window.__CSP_NONCE__ = "###NONCE###";
     </script>
 
     <link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
## Related Issues:

- [#6555](https://github.com/US-EPA-CAMD/easey-ui/issues/6555)

## Main Changes:

- Changed the NGINX replacement string from `{{nonce}}` to `###NONCE###`, since the Cloud Foundry buildpack uses double curly braces for its own templating.