### PR TITLE
fix(6564): update CSP

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,7 +41,16 @@ http {
     add_header Strict-Transport-Security max-age=15768000;
 
     # CSP (Content-Security-Policy)
-    set $csp "default-src 'self' api.epa.gov; script-src 'self' 'nonce-$request_id' https://*.googletagmanager.com https://dap.digitalgov.gov https://script.crazyegg.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data: www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; font-src 'self' https:; connect-src 'self' api.epa.gov www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://script.crazyegg.com;";
+    set $csp_default_src "'self' api.epa.gov";
+    set $csp_script_src "'self' 'nonce-$request_id' https://*.googletagmanager.com https://dap.digitalgov.gov https://*.crazyegg.com";
+    set $csp_style_src "'self' 'unsafe-inline' https:";
+    set $csp_img_src "'self' api.epa.gov data: https://*.google-analytics.com https://*.googletagmanager.com";
+    set $csp_font_src "'self' https:";
+    set $csp_connect_src "'self' api.epa.gov https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.crazyegg.com";
+    set $csp_worker_src "'self' blob:";
+
+    set $csp "default-src $csp_default_src; script-src $csp_script_src; style-src $csp_style_src; img-src $csp_img_src; font-src $csp_font_src; connect-src $csp_connect_src; worker-src $csp_worker_src;";
+
     # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
     add_header Content-Security-Policy $csp;
     # X-Content-Security-Policy (for Firefox 4.0+ and Internet Explorer 10+)


### PR DESCRIPTION
## Related Issues:

- [#6564](https://github.com/US-EPA-CAMD/easey-ui/issues/6564)

## Main Changes:

- Updated the Content Security Policy to allow several blocked requests necessary for Google Analytics:
  - Changed `script.crazyegg.com` to `*.crazyegg.com`
  - Added `worker-src: blob:`