### PR TITLE
Fix/csp 1.7

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -41,7 +41,7 @@ http {
     add_header Strict-Transport-Security max-age=31536000;
 
     # CSP (Content-Security-Policy)
-    set $csp "default-src 'self' api.epa.gov; script-src 'self' 'nonce-$request_id' https://*.googletagmanager.com https://dap.digitalgov.gov https://*.crazyegg.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data: www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; font-src 'self' https:; connect-src 'self' api.epa.gov www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.crazyegg.com; worker-src 'self' blob:";
+    set $csp "default-src 'self' api.epa.gov; script-src 'self' 'unsafe-eval' 'nonce-$request_id' https://*.googletagmanager.com https://dap.digitalgov.gov https://*.crazyegg.com; style-src 'self' 'unsafe-inline' https:; img-src 'self' api.epa.gov data: www.googletagmanager.com https://*.google-analytics.com https://*.googletagmanager.com; font-src 'self' https:; connect-src 'self' api.epa.gov www.googletagmanager.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://*.crazyegg.com; worker-src 'self' blob:";
 
     # Content-Security-Policy (for Chrome 25+, Firefox 23+, Safari 7+)
     add_header Content-Security-Policy $csp;


### PR DESCRIPTION
## Related Issues:

- [#6555](https://github.com/US-EPA-CAMD/easey-ui/issues/6555)

## Main Changes:

- Added `unsafe-eval` to `script-src`, which is necessary for some of the tags configured in Google Tag Manager.