### PR TITLE
Fix: allow API call by removing program length check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easey-campd-ui",
-  "version": "1.7",
+  "version": "1.8",
   "description": "EPA CAMD CAMPD Website application",
   "license": "MIT",
   "private": true,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@
 
 sonar.projectName="EPA CAMD EASEY CAMPD UI"
 sonar.projectDescription="CAMPD UI for the EPA CAMD Business Systems EASEY Application"
-sonar.projectVersion=v1.7
+sonar.projectVersion=v1.8
 
 sonar.organization=us-epa-camd
 sonar.host.url=https://sonarcloud.io

--- a/src/components/customDataDownload/CustomDataDownload/CustomDataDownload.js
+++ b/src/components/customDataDownload/CustomDataDownload/CustomDataDownload.js
@@ -86,8 +86,8 @@ const CustomDataDownload = ({
     dataSubType: '',
   });
   const [removedAppliedFilter, setRemovedAppliedFilter] = useState(null);
-  const [ bookmarkData, setBookmarkData ] = useState(null);
-  const [ bookmarkInit, setBookmarkInit ] = useState(false);
+  const [bookmarkData, setBookmarkData] = useState(null);
+  const [bookmarkInit, setBookmarkInit] = useState(false);
   const [applyFilterLoading, setApplyFilterLoading] = useState(false);
   const [handleApplyLoading, setHandleApplyLoading] = useState(false);
   const [localLoading, setLocalLoading] = useState(false);
@@ -97,25 +97,25 @@ const CustomDataDownload = ({
     const params = new Proxy(new URLSearchParams(window.location.search), {
       get: (searchParams, prop) => searchParams.get(prop),
     });
-    if(params.bookmarkId){
+    if (params.bookmarkId) {
       getBookmarkData(Number(params.bookmarkId)).then(res => setBookmarkData(res.data?.bookmarkData));
       setBookmarkInit(true);
     }
   }, []);
 
-  useEffect(()=>{
-    if(bookmarkInit && bookmarkData){
-      if(selectedDataType === '' && selectedDataSubtype === ''){
+  useEffect(() => {
+    if (bookmarkInit && bookmarkData) {
+      if (selectedDataType === '' && selectedDataSubtype === '') {
         updateSelectedDataTypeDispatcher(bookmarkData?.dataType);
-        const selectedDataSubtypeObj = constants.DATA_SUBTYPES_MAP[bookmarkData?.dataType].find(e=>e.label === bookmarkData?.dataSubType)
+        const selectedDataSubtypeObj = constants.DATA_SUBTYPES_MAP[bookmarkData?.dataType].find(e => e.label === bookmarkData?.dataSubType)
         setSelectedDataSubtype(selectedDataSubtypeObj.value);
-        bookmarkData.hasOwnProperty('aggregation') ? setSelectedAggregation(bookmarkData.aggregation) : setSelectedAggregation(''); 
-      }else {
+        bookmarkData.hasOwnProperty('aggregation') ? setSelectedAggregation(bookmarkData.aggregation) : setSelectedAggregation('');
+      } else {
         handleApplyButtonClick();
         window.history.pushState({}, document.title, window.location.href.split('?')[0])
       }
     }// eslint-disable-next-line
-  },[bookmarkData, selectedDataType, selectedDataSubtype]);
+  }, [bookmarkData, selectedDataType, selectedDataSubtype]);
 
   useEffect(() => {
     const resetFilters = () => {
@@ -128,7 +128,7 @@ const CustomDataDownload = ({
   }, []);
 
   useEffect(() => {
-    if (isMobileOrTablet) { 
+    if (isMobileOrTablet) {
       setDisplayCancelMobile(true);
     } else {
       setDisplayCancelMobile(false);
@@ -139,52 +139,54 @@ const CustomDataDownload = ({
 
   const fcRef = useRef(filterCriteria);
   fcRef.current = filterCriteria;
-  useEffect(()=>{//console.log(filterCriteria.timePeriod.comboBoxYear); console.log("called");
+  useEffect(() => {//console.log(filterCriteria.timePeriod.comboBoxYear); console.log("called");
     const dataSubType = getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType]);
-    if(applyClicked && loading ===0 && !handleApplyLoading){
-      if (bookmarkInit && bookmarkData?.dataPreview?.excludedColumns.length){
-        updateFilterCriteriaDispatcher({excludeParams: bookmarkData?.dataPreview?.excludedColumns})
+    if (applyClicked && loading === 0 && !handleApplyLoading) {
+      if (bookmarkInit && bookmarkData?.dataPreview?.excludedColumns.length) {
+        updateFilterCriteriaDispatcher({ excludeParams: bookmarkData?.dataPreview?.excludedColumns })
       }
-      if(selectedDataType !== "EMISSIONS" && selectedDataType !== "MERCURY AND AIR TOXICS EMISSIONS" && 
-        selectedDataType !== "FACILITY" && dataSubType !== "Transactions"){
-        if((selectedDataType === "COMPLIANCE" || dataSubType === "Holdings") && comboBoxYearUpdated === false){//console.log("updatetime");
-          const distinctYears = [...new Set(filterCriteria.filterMapping.map(e=>selectedDataType === "COMPLIANCE" ? e.year : e.vintageYear))];
+      if (selectedDataType !== "EMISSIONS" && selectedDataType !== "MERCURY AND AIR TOXICS EMISSIONS" &&
+        selectedDataType !== "FACILITY" && dataSubType !== "Transactions") {
+        if ((selectedDataType === "COMPLIANCE" || dataSubType === "Holdings") && comboBoxYearUpdated === false) {//console.log("updatetime");
+          const distinctYears = [...new Set(filterCriteria.filterMapping.map(e => selectedDataType === "COMPLIANCE" ? e.year : e.vintageYear))];
           updateTimePeriodDispatcher({
             ...filterCriteria.timePeriod,
             comboBoxYear: distinctYears.map(year => {
               return {
-                id:year, 
-                label:year, 
-                selected: bookmarkData? bookmarkData.filters?.comboBoxYear.selected.includes(year) : false, 
-                enabled: bookmarkData? bookmarkData.filters?.comboBoxYear.enabled.includes(year) 
+                id: year,
+                label: year,
+                selected: bookmarkData ? bookmarkData.filters?.comboBoxYear.selected.includes(year) : false,
+                enabled: bookmarkData ? bookmarkData.filters?.comboBoxYear.enabled.includes(year)
                   || bookmarkData.filters?.comboBoxYear.selected.includes(year) : true
-              }})
+              }
+            })
           });
           setComboBoxYearUpdated(true);
         }
-        if(dataSubType === "Account Information"){
+        if (dataSubType === "Account Information") {
           setComboBoxYearUpdated(true);
         }
-        if(comboBoxYearUpdated && !bookmarkInit){
-          const executeFilterLogic = async() => {
+        if (comboBoxYearUpdated && !bookmarkInit) {
+          const executeFilterLogic = async () => {
             await setLocalLoading(true)
             engageFilterLogic(selectedDataType, dataSubType, null, JSON.parse(JSON.stringify(fcRef.current)), updateFilterCriteriaDispatcher, setLocalLoading, true);
-          setApplyClicked(false);
-          setComboBoxYearUpdated(false);}
+            setApplyClicked(false);
+            setComboBoxYearUpdated(false);
+          }
           executeFilterLogic()
-          setTimeout(()=>changeDataTypeButton && changeDataTypeButton.focus())
+          setTimeout(() => changeDataTypeButton && changeDataTypeButton.focus())
         }
-        if(comboBoxYearUpdated && bookmarkInit){
+        if (comboBoxYearUpdated && bookmarkInit) {
           applyBookmarkFilterTags(bookmarkData, filterCriteria, addAppliedFilterDispatcher);
           setBookmarkInit(false);
           handlePreviewDataButtonClick();
           setBookmarkData(null);
         }
-      }else if(bookmarkInit && bookmarkData && filterCriteria.filterMapping.length>0){
-        let distinctYears =[];
+      } else if (bookmarkInit && bookmarkData && filterCriteria.filterMapping.length > 0) {
+        let distinctYears = [];
         const bookmarkTimePeriod = bookmarkData.filters.timePeriod;
-        if(bookmarkData.dataSubType === "Transactions"){
-          distinctYears = [...new Set(filterCriteria.filterMapping.map(e=>e.vintageYear))];
+        if (bookmarkData.dataSubType === "Transactions") {
+          distinctYears = [...new Set(filterCriteria.filterMapping.map(e => e.vintageYear))];
         }
         updateTimePeriodDispatcher({
           ...filterCriteria.timePeriod,
@@ -192,78 +194,90 @@ const CustomDataDownload = ({
           endDate: bookmarkTimePeriod.endDate,
           opHrsOnly: bookmarkTimePeriod.opHrsOnly,
           year: bookmarkTimePeriod.year,
-          comboBoxYear: distinctYears?  distinctYears.map(year => {return {
-            id:year, 
-            label:year, 
-            selected: bookmarkData.filters.comboBoxYear.selected.includes(year), 
-            enabled: bookmarkData.filters.comboBoxYear.enabled.includes(year) || bookmarkData.filters.comboBoxYear.selected.includes(year)
-          }}) : [],
+          comboBoxYear: distinctYears ? distinctYears.map(year => {
+            return {
+              id: year,
+              label: year,
+              selected: bookmarkData.filters.comboBoxYear.selected.includes(year),
+              enabled: bookmarkData.filters.comboBoxYear.enabled.includes(year) || bookmarkData.filters.comboBoxYear.selected.includes(year)
+            }
+          }) : [],
           month: bookmarkTimePeriod.month,
-          quarter: bookmarkTimePeriod.quarter, 
+          quarter: bookmarkTimePeriod.quarter,
         });
         applyBookmarkFilterTags(bookmarkData, filterCriteria, addAppliedFilterDispatcher);
         setBookmarkInit(false);
         handlePreviewDataButtonClick();
         setBookmarkData(null);
       }
-    }else if (applyClicked){
+    } else if (applyClicked) {
       setHandleApplyLoading(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  },[applyClicked, loading, comboBoxYearUpdated, bookmarkData])
+  }, [applyClicked, loading, comboBoxYearUpdated, bookmarkData])
   const changeDataTypeButton = document.querySelector('#change-data-type-button');
+  const [lastDataType, setLastDataType] = useState(null);
+  const [lastDataSubType, setLastDataSubType] = useState(null);
+
   useEffect(() => {
-    setTimeout(() =>{if (handleApplyLoading) {
-      setHideFilterMenu(true);
-      setApplyClicked(true);
-      const dataSubType = getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType]);
-      if (selectedDataType !== '' && selectedDataSubtype !== '') {
-        if(selectedDataType !== "EMISSIONS" && selectedDataType !== "FACILITY" && selectedDataType !== "MERCURY AND AIR TOXICS EMISSIONS" && dataSubType !== "Transactions"){
-          loadFilterMappingDispatcher(selectedDataType, dataSubType);
-        }else if(bookmarkInit && bookmarkData){
-          const { startDate, endDate, year } = bookmarkData.filters.timePeriod;
-          if(bookmarkData.filters.timePeriod.year.yearArray.length > 0){
-            loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, getTimePeriodYears(null, null, year.yearString));
-          }else{
-            if(bookmarkData.dataSubType === "Transactions"){
-              loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, [startDate, endDate])
-            }else if(bookmarkData.dataType === "MERCURY AND AIR TOXICS EMISSIONS" ){
-              loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, getTimePeriodYears(startDate, endDate, null));
-            }else{
-              loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, getTimePeriodYears(startDate, endDate));
+    setTimeout(() => {
+      if (handleApplyLoading) {
+        setHideFilterMenu(true);
+        setApplyClicked(true);
+        const dataSubType = getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType]);
+        if (selectedDataType !== '' && selectedDataSubtype !== '') {
+          if (selectedDataType !== "EMISSIONS" && selectedDataType !== "FACILITY" && selectedDataType !== "MERCURY AND AIR TOXICS EMISSIONS" && dataSubType !== "Transactions") {
+            loadFilterMappingDispatcher(selectedDataType, dataSubType);
+          } else if (bookmarkInit && bookmarkData) {
+            const { startDate, endDate, year } = bookmarkData.filters.timePeriod;
+            if (bookmarkData.filters.timePeriod.year.yearArray.length > 0) {
+              loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, getTimePeriodYears(null, null, year.yearString));
+            } else {
+              if (bookmarkData.dataSubType === "Transactions") {
+                loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, [startDate, endDate])
+              } else if (bookmarkData.dataType === "MERCURY AND AIR TOXICS EMISSIONS") {
+                loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, getTimePeriodYears(startDate, endDate, null));
+              } else {
+                loadFilterMappingDispatcher(bookmarkData.dataType, bookmarkData.dataSubType, getTimePeriodYears(startDate, endDate));
+              }
             }
           }
-        }
-        loadAllFiltersDispatcher(selectedDataType, dataSubType, filterCriteria, bookmarkData?.filters);
-        setDataTypeApplied(true);
-        setDataSubtypeApplied(true);
-        setAppliedDataType({
-          dataType: selectedDataType,
-          dataSubType: selectedDataSubtype,
-          aggregation: selectedAggregation,
-        });
-        updateSelectedAggregationDispatcher(selectedAggregation);
-        if (selectionChange) {
-          if(!onlyAggregationChanged){
-            removeAppliedFiltersDispatcher(null, true);
-            resetFilterDispatcher(null, true);
+          let enabledLoadProgram = lastDataSubType !== dataSubType || lastDataType !== selectedDataType
+          if (enabledLoadProgram) {
+            setLastDataSubType(dataSubType);
+            setLastDataType(selectedDataType);
           }
-          if (selectedDataType !== "EMISSIONS"){
-            setSelectedAggregation('');
-            updateSelectedAggregationDispatcher("");
+          loadAllFiltersDispatcher(selectedDataType, dataSubType, filterCriteria, enabledLoadProgram, bookmarkData?.filters);
+          setDataTypeApplied(true);
+          setDataSubtypeApplied(true);
+          setAppliedDataType({
+            dataType: selectedDataType,
+            dataSubType: selectedDataSubtype,
+            aggregation: selectedAggregation,
+          });
+          updateSelectedAggregationDispatcher(selectedAggregation);
+          if (selectionChange) {
+            if (!onlyAggregationChanged) {
+              removeAppliedFiltersDispatcher(null, true);
+              resetFilterDispatcher(null, true);
+            }
+            if (selectedDataType !== "EMISSIONS") {
+              setSelectedAggregation('');
+              updateSelectedAggregationDispatcher("");
+            }
           }
+          setSelectionChange(false);
+          setDisplayCancel(true);
+          updateSelectedDataSubTypeDispatcher(
+            getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType])
+          );
         }
-        setSelectionChange(false);
-        setDisplayCancel(true);
-        updateSelectedDataSubTypeDispatcher(
-          getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType])
-        );
+        setHandleApplyLoading(false);
+        setTimeout(() => {
+          changeDataTypeButton && changeDataTypeButton.focus()
+        })
       }
-      setHandleApplyLoading(false);
-      setTimeout(() => {
-        changeDataTypeButton && changeDataTypeButton.focus()
-      })
-    }})//eslint-disable-next-line react-hooks/exhaustive-deps
+    })//eslint-disable-next-line react-hooks/exhaustive-deps
   }, [handleApplyLoading])
   useEffect(() => {
     const noAggregationChange = appliedDataType.aggregation === selectedAggregation || !selectedAggregation;
@@ -279,19 +293,19 @@ const CustomDataDownload = ({
       appliedDataType.dataSubType === selectedDataSubtype && aggregationChange) {
       setOnlyAggregationChanged(true);
       setSelectionChange(true);
-      }else{
+    } else {
       setSelectionChange(true);
       setOnlyAggregationChanged(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedDataType, selectedDataSubtype, appliedDataType, selectedAggregation]);
 
-  useEffect(()=>{
-    if(!activeFilter && filterClickRef!==null){
+  useEffect(() => {
+    if (!activeFilter && filterClickRef !== null) {
       filterClickRef.focus();
       setFilterClickRef(null);
     }// eslint-disable-next-line react-hooks/exhaustive-deps
-  },[activeFilter]);
+  }, [activeFilter]);
 
   // *** EVENT HANDLERS
   const changeDataSubtype = (event) => {
@@ -313,7 +327,7 @@ const CustomDataDownload = ({
       setSelectedDataSubtype('');
       updateSelectedDataTypeDispatcher(value);
     }
-    if (constants.DATA_SUBTYPES_MAP[value].length === 1){
+    if (constants.DATA_SUBTYPES_MAP[value].length === 1) {
       setSelectedDataSubtype(1);
     }
   };
@@ -403,9 +417,9 @@ const CustomDataDownload = ({
     return entry ? entry.label : '';
   };
 
-  const mobileDataTypeDisplay = displayMobileDataType? 'width-full tablet:width-mobile-lg minh-viewport'
-  : 'display-none desktop:display-block';
-  const applyClickedLoading = selectedDataType === "COMPLIANCE" || getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType]) === "Holdings"? applyClicked : false;
+  const mobileDataTypeDisplay = displayMobileDataType ? 'width-full tablet:width-mobile-lg minh-viewport'
+    : 'display-none desktop:display-block';
+  const applyClickedLoading = selectedDataType === "COMPLIANCE" || getSelectedDataSubType(constants.DATA_SUBTYPES_MAP[selectedDataType]) === "Holdings" ? applyClicked : false;
   const position = isMobileOrTablet ? 'position-absolute pin-y' : 'position-static';
   return (
     <div className="position-relative">
@@ -414,11 +428,10 @@ const CustomDataDownload = ({
         data-testid="manage-data-download-wrapper"
       >
         <div
-          className={`${
-            displayFilters
+          className={`${displayFilters
               ? 'desktop:display-none desktop-lg:display-block'
               : ''
-          } side-nav side-nav-height bg-base-lighter margin-0 ${mobileDataTypeDisplay +  ' ' + position}`}
+            } side-nav side-nav-height bg-base-lighter margin-0 ${mobileDataTypeDisplay + ' ' + position}`}
         >
           <DataTypeSelectorView
             selectedDataType={selectedDataType}
@@ -453,15 +466,15 @@ const CustomDataDownload = ({
             isMobileOrTablet={isMobileOrTablet}
             setRemovedAppliedFilter={setRemovedAppliedFilter}
             renderPreviewData={renderPreviewData}
-          selectionChange={selectionChange}
+            selectionChange={selectionChange}
           />
-          <MobileMenu 
-          handleBackButtonClick={handleBackButtonClick}
-          appliedFilters={appliedFilters}
-          dataSubtypeApplied={dataSubtypeApplied}
-          handlePreviewDataButtonClick={handlePreviewDataButtonClick}
-          hideFilterMenu={hideFilterMenu}
-          resetFiltersDispatcher={resetFilterDispatcher}
+          <MobileMenu
+            handleBackButtonClick={handleBackButtonClick}
+            appliedFilters={appliedFilters}
+            dataSubtypeApplied={dataSubtypeApplied}
+            handlePreviewDataButtonClick={handlePreviewDataButtonClick}
+            hideFilterMenu={hideFilterMenu}
+            resetFiltersDispatcher={resetFilterDispatcher}
           />
         </div>
         <FilterCriteriaPanel
@@ -492,7 +505,7 @@ const CustomDataDownload = ({
           setRemovedAppliedFilter={setRemovedAppliedFilter}
           setApplyFilterLoading={setApplyFilterLoading}
         />
-        <RenderSpinner showSpinner={loading || filterCriteria.filterLogicEngaged || bookmarkInit || handleApplyLoading || applyFilterLoading || localLoading || comboBoxYearUpdated|| applyClickedLoading } />
+        <RenderSpinner showSpinner={loading || filterCriteria.filterLogicEngaged || bookmarkInit || handleApplyLoading || applyFilterLoading || localLoading || comboBoxYearUpdated || applyClickedLoading} />
       </div>
     </div>
   );
@@ -517,19 +530,19 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(updateSelectedDataSubType(dataSubType)),
     updateSelectedAggregationDispatcher: (aggregation) =>
       dispatch(updateSelectedAggregation(aggregation)),
-    updateFilterCriteriaDispatcher: (filterCriteria) => 
+    updateFilterCriteriaDispatcher: (filterCriteria) =>
       dispatch(updateFilterCriteria(filterCriteria)),
     removeAppliedFiltersDispatcher: (removedFilter, removeAll) =>
       dispatch(removeAppliedFilter(removedFilter, removeAll)),
-    loadAllFiltersDispatcher: (dataType, dataSubType, filterCriteria, bookmarkFilters) =>
-      dispatch(loadAllFilters(dataType, dataSubType, filterCriteria, bookmarkFilters)),
+    loadAllFiltersDispatcher: (dataType, dataSubType, filterCriteria, enabledLoadProgram, bookmarkFilters) =>
+      dispatch(loadAllFilters(dataType, dataSubType, filterCriteria, enabledLoadProgram, bookmarkFilters)),
     resetFilterDispatcher: (filterToReset, resetAll) =>
       dispatch(resetFilter(filterToReset, resetAll)),
     loadFilterMappingDispatcher: (dataType, dataSubType, years) =>
       dispatch(loadFilterMapping(dataType, dataSubType, years)),
     updateTimePeriodDispatcher: (timePeriod) =>
       dispatch(updateTimePeriod(timePeriod)),
-      hideNavDispatcher: (boolean) => dispatch(hideNav(boolean)),
+    hideNavDispatcher: (boolean) => dispatch(hideNav(boolean)),
   };
 };
 

--- a/src/store/actions/customDataDownload/filterCriteria.js
+++ b/src/store/actions/customDataDownload/filterCriteria.js
@@ -292,12 +292,12 @@ const dispatchAction = (result, filter, dispatch, bookmarkFilters) =>{
   }
 };
 
-export const loadAllFilters = (dataType, dataSubType, filterCriteria, bookmarkFilters) =>{
+export const loadAllFilters = (dataType, dataSubType, filterCriteria, enabledLoadProgram, bookmarkFilters) =>{
   const filters = FILTERS_MAP[dataType][dataSubType].map(obj => obj.value);
   const promises=[];
   const apiCallOrder=[];
   return(dispatch) => {
-    if(filters.includes(API_CALLING_FILTERS[0])){
+    if(enabledLoadProgram && filters.includes(API_CALLING_FILTERS[0])){
       dispatch(beginApiCall());
       promises.push(filterCriteriaApi.getPrograms(dataType, dataSubType === "Holdings"? true : false));
       apiCallOrder.push(API_CALLING_FILTERS[0]);

--- a/src/store/actions/customDataDownload/filterCriteria.js
+++ b/src/store/actions/customDataDownload/filterCriteria.js
@@ -297,7 +297,7 @@ export const loadAllFilters = (dataType, dataSubType, filterCriteria, bookmarkFi
   const promises=[];
   const apiCallOrder=[];
   return(dispatch) => {
-    if(filterCriteria.program.length === 0 && filters.includes(API_CALLING_FILTERS[0])){
+    if(filters.includes(API_CALLING_FILTERS[0])){
       dispatch(beginApiCall());
       promises.push(filterCriteriaApi.getPrograms(dataType, dataSubType === "Holdings"? true : false));
       apiCallOrder.push(API_CALLING_FILTERS[0]);

--- a/src/store/actions/customDataDownload/filterCriteria.test.js
+++ b/src/store/actions/customDataDownload/filterCriteria.test.js
@@ -76,7 +76,8 @@ describe("- Filter Criteria Async Actions -", () => {
         actions.loadAllFilters(
           'EMISSIONS',
           'Hourly Emissions',
-          initState.filterCriteria
+          initState.filterCriteria,
+          true
         )
       )
       .then(() => {


### PR DESCRIPTION
## Ticket
[CAMPD data query caching problem for Programs
](https://github.com/US-EPA-CAMD/easey-ui/issues/6660)

## Change
Removed the extra condition `filterCriteria.program.length === 0 &&` as it was preventing program API calls from being triggered and also fix #4903( programList only load when new dataSubType or new selectedDataType