### PR TITLE
feature/#6688 Remove Year Column Showing in Hourly Query

### DIFF
--- a/src/store/actions/customDataDownload/customDataDownload.js
+++ b/src/store/actions/customDataDownload/customDataDownload.js
@@ -65,9 +65,16 @@ export function loadDataPreview(dataType, dataSubType, filterCriteria, aggregati
     dispatch(beginApiCall());
     return mapSelectionToApiCall(dataType, dataSubType, filterCriteria, aggregation, () => dispatch(setApiError('dataPreview', true)))
     .then((res) => {
+      let fieldMappings = JSON.parse(res.headers['x-field-mappings'] || '[]');
+      
+      // Remove the 'Year' column for Hourly Emissions with no aggregation
+      if (dataType === 'EMISSIONS' && dataSubType === 'Hourly Emissions' && aggregation === '') {
+        fieldMappings = fieldMappings.filter(mapping => mapping.value !== 'year');
+      }
+
       const excludableColumns = res.headers?.['x-excludable-columns']?  JSON.parse(res.headers['x-excludable-columns']) : [];
       dispatch(
-        loadDataPreviewSuccess((res.data?.items ?? res.data), res.headers['x-total-count'], JSON.parse(res.headers['x-field-mappings']), excludableColumns)
+        loadDataPreviewSuccess((res.data?.items ?? res.data), res.headers['x-total-count'], fieldMappings, excludableColumns)
       );
     })
     .catch((err) => {


### PR DESCRIPTION
### **Related Ticket:**

- ticket [#6688](https://github.com/orgs/US-EPA-CAMD/projects/2/views/57?sliceBy%5Bvalue%5D=EvanSun220&pane=issue&itemId=108892328&issue=US-EPA-CAMD%7Ceasey-ui%7C6688)

### **Updates:**

- Removed the 'year' field in the response header 'x-field-mappings' property for Hourly Emissions with no aggregation result table on custom data download page.
