### PR TITLE
CAMPD 508 remediation Viz Gallery in dev

### DIFF
--- a/src/components/HeroSlideshow/HeroSlideshow.js
+++ b/src/components/HeroSlideshow/HeroSlideshow.js
@@ -41,6 +41,7 @@ const HeroSlideshow = ({ slides }) => {
           infiniteLoop={false}
           renderIndicator={(handler, isSelected, idx) => (
             <Button
+              aria-label={`Carousel ${idx + 1}`} 
               style={{ backgroundColor: isSelected ? "#1a4480" : "#71767a" }}
               onClick={handler}
             >

--- a/src/components/HeroSlideshow/HeroSlideshow.js
+++ b/src/components/HeroSlideshow/HeroSlideshow.js
@@ -33,6 +33,7 @@ const HeroSlideshow = ({ slides }) => {
     <div className="hero-slideshow">
       <div>
         <Carousel
+          showStatus={false}
           autoPlay={true}
           swipeable={false}
           showArrows={false}


### PR DESCRIPTION
ticket:
https://github.com/US-EPA-CAMD/easey-ui/issues/7019

changes:
By default react-responsive-carousel enables showStatus = true to show the slide correctly on. To remove this showStatus has to be set to false. 